### PR TITLE
Use decouple to read environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.pyc
 .coverage
 __pycache__/
-config.ini
 htmlcov/
 build/
 dist/

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,6 @@ Installation
 Usage
 -----
 
-Copy `config.ini.example` as `config.ini` and edit it with your own credentials. If you don't plan to upload anything to S3 please don't bother about keys and secrets in this file.
-
 Example 1: How do I download the datasets?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,5 +1,0 @@
-[Amazon]
-Bucket: serenata-de-amor-data
-AccessKey: YOUR_ACCESS_KEY
-Region: sa-east-1
-SecretKey: YOUR_SECRET_KEY

--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -16,8 +16,8 @@ class Datasets:
     and the default value is data/ (following the default usage in the main
     repo, serenata-de-amor).
 
-    The remote part of the class expect to find Amazon credentials in a
-    config.ini file with an Amazon section (e.g. config.ini.exemple).
+    The remote part of the class expect to find Amazon credentials in
+    environment variables.
 
     Inside it object there are three main objects: local, remote, and
     downloader:

--- a/serenata_toolbox/datasets/helpers.py
+++ b/serenata_toolbox/datasets/helpers.py
@@ -56,30 +56,3 @@ def save_to_csv(df, data_dir, name):
     today = datetime.strftime(datetime.now(), '%Y-%m-%d')
     file_path = os.path.join(data_dir, '{}-{}.xz'.format(today, name))
     df.to_csv(file_path, **CSV_PARAMS)
-
-
-# Utility for config file lookup (credits to fabric fabfile lookup)
-
-def find_config(name='config.ini'):
-    """
-    :param name: config file name (defaults to 'config.ini')
-    """
-    # start in cwd and work downwards towards filesystem root
-    path = '.'
-    # Stop before falling off root of filesystem (should be platform
-    # agnostic)
-    while os.path.split(os.path.abspath(path))[1]:
-        joined = os.path.join(path, name)
-
-        # return config file absolute path if exists
-        if os.path.exists(joined) and os.path.isfile(joined):
-            return os.path.abspath(joined)
-
-        path = os.path.join('..', path)
-
-    # if config not found fallback on tests expected behavior
-    # wich is to return the filename to be used at remote
-    # config_exists class property.
-    # a future refactor could be to return None and not use
-    # config exists anymore
-    return name

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -1,89 +1,43 @@
 import os
-import configparser
 from functools import partial
 
 import boto3
+from decouple import config
 
 from serenata_toolbox import log
 from serenata_toolbox.datasets.contextmanager import status_message
-from serenata_toolbox.datasets.helpers import find_config
 
 
 class RemoteDatasets:
 
-    CONFIG = 'config.ini'
-
     def __init__(self):
-        self.credentials = None
         self.client = None
-        self.config = find_config(self.CONFIG)
-
-        if not self.config_exists:
-            log.info('Could not find {} file.'.format(self.CONFIG))
-            log.info('You need Amazon section in it to interact with S3')
-            log.info('(Check config.ini.example if you need a reference.)')
-            return
-
-        settings = configparser.RawConfigParser()
-        settings.read(self.config)
-        self.settings = partial(settings.get, 'Amazon')
-
-        try:
-            self.credentials = {
-                'aws_access_key_id': self.settings('AccessKey'),
-                'aws_secret_access_key': self.settings('SecretKey'),
-                'region_name': self.settings('Region')
-            }
-
-            # friendly user message warning about old config.ini version
-            region = self.credentials.get('region_name', '')
-            if region and region.startswith('s3-'):
-                msg = (
-                    'It looks like you have an old version of the config.ini '
-                    'file. We do not need anymore the service (s3) appended '
-                    'to the region (sa-east-1). Please update your config.ini '
-                    'replacing regions like `s3-sa-east-1` by `sa-east-1`.'
-                )
-                log.info(msg)
-
-        except configparser.NoSectionError:
-            msg = (
-                'You need an Amazon section in {} to interact with S3 '
-                '(Check config.ini.example if you need a reference.)'
-            )
-            log.info(msg.format(self.CONFIG))
-
-    @property
-    def config_exists(self):
-        return all((os.path.exists(self.config), os.path.isfile(self.config)))
+        self.credentials = {
+            'aws_access_key_id': config('AMAZON_ACCESS_KEY'),
+            'aws_secret_access_key': config('AMAZON_SECRET_KEY'),
+            'region_name': config('AMAZON_REGION'),
+        }
 
     @property
     def bucket(self):
-        if hasattr(self, 'settings'):
-            try:
-                return self.settings('Bucket')
-            except configparser.NoSectionError:
-                return None
+        return config('AMAZON_BUCKET')
 
     @property
     def s3(self):
-        if not self.client and self.credentials:
+        if not self.client:
             self.client = boto3.client('s3', **self.credentials)
         return self.client
 
     @property
     def all(self):
-        if self.s3 and self.bucket:
-            response = self.s3.list_objects(Bucket=self.bucket)
-            yield from (obj.get('Key') for obj in response.get('Contents', []))
+        response = self.s3.list_objects(Bucket=self.bucket)
+        yield from (obj.get('Key') for obj in response.get('Contents', []))
 
     def upload(self, file_path):
-        if self.s3 and self.bucket:
-            _, file_name = os.path.split(file_path)
-            with status_message('Uploading {}…'.format(file_name)):
-                self.s3.upload_file(file_path, self.bucket, file_name)
+        _, file_name = os.path.split(file_path)
+        with status_message('Uploading {}…'.format(file_name)):
+            self.s3.upload_file(file_path, self.bucket, file_name)
 
     def delete(self, file_name):
-        if self.s3 and self.bucket:
-            with status_message('Deleting {}…'.format(file_name)):
-                self.s3.delete_object(Bucket=self.bucket, Key=file_name)
+        with status_message('Deleting {}…'.format(file_name)):
+            self.s3.delete_object(Bucket=self.bucket, Key=file_name)

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
     ],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='13.0.0',
+    version='14.0.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'beautifulsoup4>=4.4',
         'lxml>=3.6',
         'pandas>=0.18',
+        'python-decouple>=3.1',
         'tqdm'
     ],
     keywords='serenata de amor, data science, brazil, corruption',

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -87,34 +87,5 @@ class TestDatasetsHelpersDataframes(TestCase):
         )
 
 
-class TestDatasetsHelpersConfigLookup(TestCase):
-
-    def setUp(self):
-        # good case
-        self.root = os.path.realpath(tempfile.mkdtemp())
-        self.subfolder = os.path.relpath(tempfile.mkdtemp(dir=self.root))
-        self.config_file = os.path.join(self.root, 'config.ini')
-        self.cwd = os.getcwd()
-        open(self.config_file, 'a').close()
-
-        # not found case
-        self.root_not_found = os.path.relpath(tempfile.mkdtemp())
-
-        # not a file case
-        self.root_not_a_file = os.path.relpath(tempfile.mkdtemp())
-        self.config_folder = os.path.join(self.root_not_a_file, 'config.ini')
-        os.makedirs(self.config_folder)
-
-
-    def tearDown(self):
-        os.chdir(self.cwd)
-        os.remove(self.config_file)
-        os.rmdir(self.subfolder)
-        os.rmdir(self.root)
-        os.rmdir(self.root_not_found)
-        os.rmdir(self.config_folder)
-        os.rmdir(self.root_not_a_file)
-
-
 if __name__ == '__main__':
     main()

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -115,21 +115,6 @@ class TestDatasetsHelpersConfigLookup(TestCase):
         os.rmdir(self.config_folder)
         os.rmdir(self.root_not_a_file)
 
-    def test_find_config(self):
-        os.chdir(self.subfolder)
-
-        self.assertEqual(helpers.find_config(), self.config_file)
-
-    def test_find_config_not_found(self):
-        os.chdir(self.root_not_found)
-
-        self.assertEqual(helpers.find_config(), 'config.ini')
-
-    def test_find_config_a_file(self):
-        os.chdir(self.root_not_a_file)
-
-        self.assertEqual(helpers.find_config(), 'config.ini')
-
 
 if __name__ == '__main__':
     main()

--- a/tests/unit/test_datasets_remote.py
+++ b/tests/unit/test_datasets_remote.py
@@ -1,116 +1,44 @@
-from configparser import NoSectionError, RawConfigParser
+import os
 from unittest import TestCase
 from unittest.mock import PropertyMock, patch
 
 from serenata_toolbox.datasets.remote import RemoteDatasets
 
 
+os.environ['AMAZON_ACCESS_KEY'] = 'YOUR_ACCESS_KEY'
+os.environ['AMAZON_SECRET_KEY'] = 'YOUR_SECRET_KEY'
+os.environ['AMAZON_BUCKET'] = 'YOUR_BUCKET'
+os.environ['AMAZON_REGION'] = 'sa-east-1'
+
+
 class TestRemote(TestCase):
 
-    @patch('serenata_toolbox.datasets.remote.os.path.exists')
-    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
-    def test_config_exists_when_it_doesnt_exist(self, is_file, exists):
-        exists.return_value = False
-        is_file.return_value = False
+    def test_init(self):
         remote = RemoteDatasets()
-        self.assertFalse(remote.config_exists)
+        self.assertIsNotNone(remote.s3)
+        self.assertIsNotNone(remote.bucket)
 
-    @patch('serenata_toolbox.datasets.remote.os.path.exists')
-    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
-    def test_config_exists_when_it_is_a_directory(self, is_file, exists):
-        exists.return_value = True
-        is_file.return_value = False
-        remote = RemoteDatasets()
-        self.assertFalse(remote.config_exists)
-
-    @patch('serenata_toolbox.datasets.remote.os.path.exists')
-    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
-    def test_config_exists_when_it_is_a_file(self, is_file, exists):
-        exists.return_value = True
-        is_file.return_value = True
-        remote = RemoteDatasets()
-        self.assertTrue(remote.config_exists)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.log.info')
-    def test_init_without_config(self, print_, config_exist):
-        config_exist.return_value = False
-        remote = RemoteDatasets()
-        self.assertIsNone(remote.s3)
-        self.assertIsNone(remote.bucket)
-        self.assertTrue(print_.called)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.log.info')
     @patch('serenata_toolbox.datasets.remote.boto3')
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_init_with_old_config(self, raw_config_parser, boto3, print_, config_exists):
-        raw_config_parser.return_value.get.return_value = 's3-test'
-        RemoteDatasets()
-        expected = (
-            'It looks like you have an old version of the config.ini file. We '
-            'do not need anymore the service (s3) appended to the region '
-            '(sa-east-1). Please update your config.ini replacing regions '
-            'like `s3-sa-east-1` by `sa-east-1`.'
-        )
-        print_.assert_called_once_with(expected)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.boto3')
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_successful_init(self, raw_config_parser, boto3, config_exists):
-        raw_config_parser.return_value.get.side_effect = (
-            'YOUR_ACCESS_KEY',
-            'YOUR_SECRET_KEY',
-            'sa-east-1',
-            'serenata-de-amor-data'
-        )
+    def test_successful_init(self, boto3):
         credentials = {
             'aws_access_key_id': 'YOUR_ACCESS_KEY',
             'aws_secret_access_key': 'YOUR_SECRET_KEY',
             'region_name': 'sa-east-1'
         }
         remote = RemoteDatasets()
-        self.assertEqual('serenata-de-amor-data', remote.bucket)
+        self.assertEqual('YOUR_BUCKET', remote.bucket)
         self.assertEqual(credentials, remote.credentials)
 
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    def test_bucket_no_config(self, config_exists):
-        config_exists.return_value = False
-        remote = RemoteDatasets()
-        self.assertIsNone(remote.bucket)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_bucket_no_section(self, raw_config_parser, config_exists):
-        config_exists.return_value = True
-        raw_config_parser.return_value.get.side_effect = NoSectionError('foo')
-        remote = RemoteDatasets()
-        self.assertIsNone(remote.bucket)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_bucket(self, raw_config_parser, config_exists):
-        config_exists.return_value = True
-        raw_config_parser.return_value.get.return_value = "42"
-        remote = RemoteDatasets()
-        self.assertEqual("42", remote.bucket)
-
-    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
     @patch('serenata_toolbox.datasets.remote.boto3')
-    def test_s3(self, boto3, raw_config_parser, config_exists):
-        config_exists.return_value = True
+    def test_s3(self, boto3):
         remote = RemoteDatasets()
         remote.credentials = dict(test=42)
         self.assertIsNotNone(remote.s3)
         boto3.client.assert_called_once_with('s3', test=42)
-        remote.client = remote.s3
 
-    @patch.object(RemoteDatasets, 'config_exists')
     @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
     @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
-    def test_all(self, bucket, s3, config_exists):
+    def test_all(self, bucket, s3):
         response = {'Contents': [{'Key': 'file1.xz'}, {'Key': 'file2.xz'}]}
         s3.return_value.list_objects.return_value = response
         bucket.return_value = 'bucket'
@@ -118,10 +46,9 @@ class TestRemote(TestCase):
         self.assertEqual(('file1.xz', 'file2.xz'), tuple(remote.all))
 
     @patch('serenata_toolbox.datasets.contextmanager.print')
-    @patch.object(RemoteDatasets, 'config_exists')
     @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
     @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
-    def test_upload(self, bucket, s3, config_exists, print_):
+    def test_upload(self, bucket, s3, print_):
         bucket.return_value = 'serenata-de-amor-data'
         remote = RemoteDatasets()
         remote.upload('/root/serenata/data/42.csv')
@@ -132,10 +59,9 @@ class TestRemote(TestCase):
         )
 
     @patch('serenata_toolbox.datasets.contextmanager.print')
-    @patch.object(RemoteDatasets, 'config_exists')
     @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
     @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
-    def test_delete(self, bucket, s3, config_exists, print_):
+    def test_delete(self, bucket, s3, print_):
         bucket.return_value = 'serenata-de-amor-data'
         remote = RemoteDatasets()
         remote.delete('42.csv')


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Instead of using `config.ini` to read the environment variables, we are now using `python-decouple` which cleans the code, and make it simple

**What was done to achieve this purpose?**
@Irio and I have studied all the references of `configparser` and `config.ini` and worked on removing and updating all of the references to `python-decouple`

**How to test if it really works?**
Run the tests

**Who can help reviewing it?**
@Irio @cuducos 

