### PR TITLE
Make .env file completely optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.pyc
 .coverage
+.pytest_cache/
 __pycache__/
 htmlcov/
 build/

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Usage
 Example 1: How do I download the datasets?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We have `plenty of them <https://github.com/datasciencebr/serenata-de-amor/blob/master/CONTRIBUTING.md#datasets-data>`_ ready for you to download from our servers. And this toolbox helps you get them. Let's say you want your datasets at `data/`:
+We have `plenty of them <https://github.com/okfn-brasil/serenata-de-amor/blob/master/research/CONTRIBUTING.md#datasets-data>`_ ready for you to download from our servers. And this toolbox helps you get them. Let's say you want your datasets at `data/`:
 
 .. code:: python
 
@@ -78,20 +78,21 @@ If the last example doesn't look that simple, there are some fancy shortcuts ava
 Example 3: Generating datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you ever wonder how did we generated these datasets, this toolbox can help you too (at least with the more used ones — the other ones are generated `in our main repo <https://github.com/datasciencebr/serenata-de-amor/blob/master/CONTRIBUTING.md#the-toolbox-and-our-the-source-files-src>`_):
+If you ever wonder how did we generated these datasets, this toolbox can help you too (at least with the more used ones — the other ones are generated `in our main repo <https://github.com/okfn-brasil/serenata-de-amor/blob/master/research/CONTRIBUTING.md#the-toolbox-and-our-the-source-files-src>`_):
 
 .. code:: python
 
     from serenata_toolbox.federal_senate.dataset import Dataset as SenateDataset
     from serenata_toolbox.chamber_of_deputies.reimbursements import Reimbursements as ChamberDataset
 
+    chamber = ChamberDataset('2018', 'data/')
+    chamber()
+
     senate = SenateDataset('data/')
     senate.fetch()
     senate.translate()
     senate.clean()
 
-    chamber = ChamberDataset('2018', 'data/')
-    chamber()
 Documentation (WIP)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,10 @@ Installation
 
     $ pip install -U serenata-toolbox
 
+If you are a regular user you are ready to get started after `pip install`.
+
+If you are a core developer willing to upload datasets to the cloud you need to configure `AMAZON_ACCESS_KEY` and `AMAZON_SECRET_KEY` environment variables before running the toolbox.
+
 Usage
 -----
 
@@ -88,7 +92,6 @@ If you ever wonder how did we generated these datasets, this toolbox can help yo
 
     chamber = ChamberDataset('2018', 'data/')
     chamber()
-
 Documentation (WIP)
 -------------------
 

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -1,10 +1,8 @@
 import os
-from functools import partial
 
 import boto3
-from decouple import config
 
-from serenata_toolbox import log
+from serenata_toolbox import settings
 from serenata_toolbox.datasets.contextmanager import status_message
 
 
@@ -13,14 +11,11 @@ class RemoteDatasets:
     def __init__(self):
         self.client = None
         self.credentials = {
-            'aws_access_key_id': config('AMAZON_ACCESS_KEY', default=None),
-            'aws_secret_access_key': config('AMAZON_SECRET_KEY', default=None),
-            'region_name': config('AMAZON_REGION'),
+            'aws_access_key_id': settings.AMAZON_ACCESS_KEY,
+            'aws_secret_access_key': settings.AMAZON_SECRET_KEY,
+            'region_name': settings.AMAZON_REGION,
         }
-
-    @property
-    def bucket(self):
-        return config('AMAZON_BUCKET')
+        self.bucket = settings.AMAZON_BUCKET
 
     @property
     def s3(self):

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -8,14 +8,16 @@ from serenata_toolbox.datasets.contextmanager import status_message
 
 class RemoteDatasets:
 
+    BUCKET = settings.AMAZON_BUCKET
+    CREDENTIALS = (
+        ('aws_access_key_id', settings.AMAZON_ACCESS_KEY),
+        ('aws_secret_access_key', settings.AMAZON_SECRET_KEY),
+        ('region_name', settings.AMAZON_REGION),
+    )
+
     def __init__(self):
         self.client = None
-        self.credentials = {
-            'aws_access_key_id': settings.AMAZON_ACCESS_KEY,
-            'aws_secret_access_key': settings.AMAZON_SECRET_KEY,
-            'region_name': settings.AMAZON_REGION,
-        }
-        self.bucket = settings.AMAZON_BUCKET
+        self.credentials = {k: v for k, v in self.CREDENTIALS if v}
 
     @property
     def s3(self):
@@ -25,14 +27,14 @@ class RemoteDatasets:
 
     @property
     def all(self):
-        response = self.s3.list_objects(Bucket=self.bucket)
+        response = self.s3.list_objects(Bucket=self.BUCKET)
         yield from (obj.get('Key') for obj in response.get('Contents', []))
 
     def upload(self, file_path):
         _, file_name = os.path.split(file_path)
         with status_message('Uploading {}…'.format(file_name)):
-            self.s3.upload_file(file_path, self.bucket, file_name)
+            self.s3.upload_file(file_path, self.BUCKET, file_name)
 
     def delete(self, file_name):
         with status_message('Deleting {}…'.format(file_name)):
-            self.s3.delete_object(Bucket=self.bucket, Key=file_name)
+            self.s3.delete_object(Bucket=self.BUCKET, Key=file_name)

--- a/serenata_toolbox/settings.py
+++ b/serenata_toolbox/settings.py
@@ -1,0 +1,7 @@
+from decouple import config
+
+
+AMAZON_ACCESS_KEY = config('AMAZON_ACCESS_KEY', default=None)
+AMAZON_SECRET_KEY = config('AMAZON_SECRET_KEY', default=None)
+AMAZON_REGION = config('AMAZON_REGION', default='sa-east-1')
+AMAZON_BUCKET = config('AMAZON_BUCKET', default='serenata-de-amor-data')

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
     ],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='14.0.1',
+    version='14.0.2',
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Fix bug #183 

**What was done to achieve this purpose?**

I made all environment variables completely optional and adder a note on `README.rst` that only core developers uploading new datasets need to care about these variables.

**How to test if it really works?**

1. Install the package from this branch (not from PyPI)<br>`pip install https://github.com/okfn-brasil/serenata-toolbox/archive/cuducos-optional-env-file.zip`
2. Run some example code from the `README.rst` such as:

```python
from serenata_toolbox.chamber_of_deputies.reimbursements import Reimbursements as ChamberDataset

ChamberDataset('2018', '/tmp')()
```
It should work even without **any** environment variable configured. Trying to download from S3 should fail though: our S3 died and we are setting a new one (new PR to come).

**Who can help reviewing it?**

It was reviewed from the user poit of view by @vilapedro.

@mnunes: would you mind testing to check if it fixes the bug in your use case?

@irio, @anaschwendler and @jtemporal can offer a technical review too : )

**TODO**

- [x] Fix error raised in Travis CI (in this PR)
- [ ] Setup a new bucket/storage (in a new PR)
