### PR TITLE
Reimbursements cleaner tuning

### DIFF
--- a/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
@@ -155,18 +155,11 @@ class ReimbursementsCleaner:
         return data
 
     def _non_house_payments(self):
-        def aggregate_attributes(df):
-            reimbursement_numbers = df['reimbursement_number'].tolist()
-            total_net_value = df['net_value'].sum()
-            total_reimbursement_value = df['reimbursement_value'].sum()
-            attributes = pd.Series({
-                'numbers': reimbursement_numbers,
-                'total_net_value': total_net_value,
-                'total_value': total_reimbursement_value,
-            })
-            attributes = pd.concat([df.iloc[0], attributes])
-            attributes.drop(AGGREGATED_COLS.keys(), inplace=True)
-            return attributes
-
-        data = self.data[self.data['reimbursement_number'] != '0']
-        return data.groupby(KEY).apply(aggregate_attributes)
+        data = self.data[self.data['reimbursement_number'] != '0'].copy()
+        data.rename(columns=AGGREGATED_COLS, inplace=True)
+        attributes = {key: 'first' for key in sorted(data.columns)}
+        attributes['numbers'] = lambda x: list(x)
+        attributes['total_net_value'] = 'sum'
+        attributes['total_value'] = 'sum'
+        del attributes['document_id']
+        return data.groupby(KEY, as_index=False).agg(attributes)

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     ],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='15.0.1',
+    version='15.0.2',
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

 Improve reimbursements cleaning stage performance. 
 Running this stage in Rosie for chamber_of_deputies took 7 minutes instead 53 minutes. 

**What was done to achieve this purpose?**

 I've changed the pandas function responsible for aggregation of values. 
 Changing pandas.core.groupby.GroupBy.apply(), considered [slower than other methods](https://pandas.pydata.org/pandas-docs/version/0.21/generated/pandas.core.groupby.GroupBy.apply.html), to pandas.core.groupby.DataFrameGroupBy.agg().

**How to test if it really works?**

Run Rosie (rosie.py run chamber_of_deputies) using both pandas functions and compare the output generated (reimbursements-<year>.csv files) and measure time of this stage.

**Who can help reviewing it?**

@cuducos @Irio @vitorbaptista 
