### PR TITLE
Fixing running serenata-toolbox into jupyter with tornado 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ jobs:
 
 install:
   - rm -rf .coverage
-  - python -m pip install -e .
-  - python -m pip install coveralls pytest pytest-cov
+  - python -m pip install -e .[dev]
 
 after_success:
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ Always add tests to your contribution — if you want to test it locally before
 
 .. code-block:: bash
 
-  $ pip install pytest pytest-cov
+  $ pip install -e .[dev]
   $ pytest
 
 When the tests are passing, also check for coverage of the modules you edited or added — if you want to check it before opening the PR:
@@ -155,14 +155,14 @@ Follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ and best practices im
 
 .. code-block:: bash
 
-  $ pip install prospector
+  $ pip install -e .[dev]
   $ prospector -s veryhigh serenata_toolbox
 
 If this report includes issues related to `import` section of your files, `isort <https://github.com/timothycrosley/isort>`_ can help you:
 
 .. code-block:: bash
 
-  $ pip install isort
+  $ pip install -e .[dev]
   $ isort **/*.py --diff
 
 Always suggest a version bump. We use `Semantic Versioning <http://semver.org>`_ – or in `Elm community words <https://github.com/elm-lang/elm-package#version-rules>`_:

--- a/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
@@ -141,8 +141,9 @@ class ReimbursementsCleaner:
     def aggregate_multiple_payments(self):
         self.data = pd.concat([
             self._house_payments(),
-            self._non_house_payments(),
-        ])
+            self._non_house_payments()],
+            sort=True,
+        )
 
     def save(self):
         file_path = os.path.join(self.path, f'reimbursements-{self.year}.csv')

--- a/serenata_toolbox/datasets/downloader.py
+++ b/serenata_toolbox/datasets/downloader.py
@@ -75,7 +75,7 @@ class Downloader:
             return
 
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.main(loop, files))
+        loop.create_task(self.main(loop, files))
 
     async def main(self, loop, files):
         desc = 'Downloading {} files'.format(len(files))

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     scripts=['serenata_toolbox/serenata-toolbox'],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='15.1.0',
+    version='15.1.1',
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,13 @@ setup(
         'python-decouple>=3.1',
         'tqdm'
     ],
+    extras_require={
+        'dev': [
+            "prospector",
+            "pytest",
+            "pytest-cov"
+        ]
+    },
     keywords='serenata de amor, data science, brazil, corruption',
     license='MIT',
     long_description=long_description,

--- a/tests/unit/test_datasets_downloader.py
+++ b/tests/unit/test_datasets_downloader.py
@@ -62,7 +62,7 @@ class TestDownloader(TestCase):
         downloader.download('test.xz')
         asyncio_.get_event_loop.assert_called_with()
         loop = asyncio_.get_event_loop.return_value
-        self.assertTrue(loop.run_until_complete.called)
+        self.assertTrue(loop.create_task.called)
         main.assert_called_once_with(loop, ('test.xz',))
 
     @patch.object(Downloader, 'main')
@@ -76,7 +76,7 @@ class TestDownloader(TestCase):
         downloader.download(range(3))
         asyncio_.get_event_loop.assert_called_with()
         loop = asyncio_.get_event_loop.return_value
-        self.assertTrue(loop.run_until_complete.called)
+        self.assertTrue(loop.create_task.called)
         main.assert_called_once_with(loop, (1, 2))
 
     @patch('serenata_toolbox.datasets.downloader.os.path.isdir')


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
This PR aims to fix running serenata-toolbox into jupyter with tornado 5.0.

**What was done to achieve this purpose?**

Following the issue thread [here](https://github.com/jupyter/notebook/issues/3397), I changed the way to launch a task in the Downloader class.

**How to test if it really works?**

Try to follow [this documentation step](https://github.com/okfn-brasil/serenata-toolbox#example-2-how-do-i-download-the-datasets) using a jupyter notebook with tornado 5.0 and face a `RuntimeError: This event loop is already running` exception. After that, try to install using my branch and realize that exception has disappeared.

**Who can help reviewing it?**

Anyone involved in the project.
