### PR TITLE
Fix for new CSV format adopted by the Chamber of Deputies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
 
 install:
   - rm -rf .coverage
-  - python -m pip install -e .
-  - python -m pip install coveralls pytest pytest-cov==2.5.1
+  - python -m pip install -U -e .
+  - python -m pip install -U coveralls pytest pytest-cov
 
 after_success:
   - coveralls

--- a/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
@@ -90,15 +90,6 @@ DTYPE = {
     'nuDeputadoId': np.str,
     'ideDocumento': np.str,
 }
-
-
-def parse_float(value):
-    return float(value.replace(',', '.'))
-
-
-CONVERTERS = {
-    'vlrRestituicao': parse_float,
-}
 KEY = 'document_id'
 AGGREGATED_COLS = {
     'reimbursement_number': 'numbers',

--- a/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
@@ -127,8 +127,6 @@ class ReimbursementsCleaner:
         file_path = os.path.join(self.path, f'Ano-{self.year}.csv')
         self.data = pd.read_csv(file_path,
                                 delimiter=';',
-                                quoting=csv.QUOTE_NONE,
-                                decimal=',',
                                 dtype=DTYPE,
                                 low_memory=False)
 

--- a/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements_cleaner.py
@@ -130,8 +130,8 @@ class ReimbursementsCleaner:
     def aggregate_multiple_payments(self):
         self.data = pd.concat([
             self._house_payments(),
-            self._non_house_payments(),
-        ])
+            self._non_house_payments()
+        ], sort=False)
 
     def save(self):
         file_path = os.path.join(self.path, f'reimbursements-{self.year}.csv')

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     scripts=['serenata_toolbox/serenata-toolbox'],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='15.1.1',
+    version='15.1.2',
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
The toolbox was crashing when trying to read the CSV from the Chamber of Deputies. The CSV format changed a bit (decimals as `.` not as `,` anymore, values wrapped in double quotes).

**What was done to achieve this purpose?**
c0c54aa informs `pandas.read_csv` about these changes. The rest of the commits are minor updates and cleanups.

**How to test if it really works?**
Run `pytest` or the toolbox itself and expect no error (merely a warning from Pandas code-base).