### PR TITLE
WIP: Allow the toolbox to be installed in Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.egg-info/
 *.pyc
-.coverage
+.*swp
+.coverage*
 .pytest_cache/
+.tox/
 __pycache__/
-htmlcov/
 build/
 dist/
-.*swp
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
+dist: trusty
 language: python
-python: 3.6
+python:
+  - 3.6
+  - 3.7
+
 cache:
   directories:
     - $HOME/virtualenv/python3.6/
+    - $HOME/virtualenv/python3.7/
 
 jobs:
   include:
-    - stage: unit
-      script: pytest tests/unit
-
-    - stage: journey
-      script: travis_wait 40 pytest tests/journey
+    - stage: tests
+      script: tox
 
     - stage: deploy
       script: skip
@@ -22,10 +24,20 @@ jobs:
         on:
           branch: master
 
+before_install:
+  - git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+  - PYENV_ROOT="$HOME/.pyenv"
+  - PATH="$PYENV_ROOT/bin:$PATH"
+  - eval "$(pyenv init -)"
+  - pyenv install 3.6.8
+  - pyenv install 3.7.3
+  - pyenv local 3.6.8 3.7.3
 install:
-  - rm -rf .coverage
+  - coverage erase
+  - python -m pip install -U tox
   - python -m pip install -U -e .
-  - python -m pip install -U coveralls pytest pytest-cov
 
 after_success:
+  - coverage combine
+  - coverage report
   - coveralls

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Utilities',
     ],
     description='Toolbox for Serenata de Amor project',
@@ -39,5 +40,5 @@ setup(
     scripts=['serenata_toolbox/serenata-toolbox'],
     url=REPO_URL,
     python_requires='>=3.6',
-    version='15.1.4',
+    version='15.1.5',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py36, py37
+
+[testenv]
+commands = py.test
+setenv =
+    COVERAGE_FILE = .coverage.{envname}
+deps =
+    coveralls
+    pytest
+    pytest-cov


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Today @diilua warned me she was facing some issues installing the toolbox in Python 3.7. As far as I remember we haven't included Python 3.7 in `setup.py` because some third-party dependencies weren't compatible (probably something related to the new reserved keyword `async`). If I'm right, I think now this issue is gone and we can use the toolbox in Python 3.7.

**What was done to achieve this purpose?**

Added 3.7 as a supported Python version in `setup.py` and add it to Travis CI test suite.

**How to test if it really works?**

I installed my branch in a Python 3.7 virtualenv and tested the CLI with `serenata-toolbox --module chamber_of_deputies  data --year 2019`. To be honest I haven't tested other apps.

**Who can help reviewing it?**
@sergiomario @diilua

**TODO**

1. ~~In this PR I would like to wait to see if Travis works with the edits on `.travis.yml`~~
2. ~~It think that in another PR we could use `tox` to run tests in two different Python versions (3.6 and 3.7) – once we merge this we can create a proper issue for that~~

My previous strategy didn't work, so I need to find a new way for Travis to run tests in Python 3.6 and 3.7. Any ideas?